### PR TITLE
Fix autocomplete outside click behavior

### DIFF
--- a/app/static/js/sales_form/autocomplete.js
+++ b/app/static/js/sales_form/autocomplete.js
@@ -15,8 +15,16 @@ export class Autocomplete {
   bind() {
     this.input.addEventListener('input', () => this.render());
     this.input.addEventListener('focus', () => this.render());
-    this.input.addEventListener('blur', () => setTimeout(() => this.hide(), 150));
+    this.list.addEventListener('mousedown', e => {
+      e.preventDefault();
+      this.onClick(e);
+    });
     this.list.addEventListener('click', e => this.onClick(e));
+    document.addEventListener('mousedown', e => {
+      if (!this.list.contains(e.target) && e.target !== this.input) {
+        this.hide();
+      }
+    });
     this.input.addEventListener('keydown', e => this.onKeyDown(e));
   }
 


### PR DESCRIPTION
## Summary
- keep list visible during mousedown on an item
- hide autocomplete list when clicking outside

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840e00be57c83329d1361e880390a9c