### PR TITLE
Fix autocomplete blur handling

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -113,13 +113,20 @@ body {
    Payment & Discount Action Buttons
    ========================================================================== */
 #add-payment,
+#add-change,
 #add-discount {
   width: 200px;
 }
 
+#add-change {
+  background-color: #d8c6ec;
+  border-color: #d8c6ec;
+  color: #000;
+}
+
 #add-discount {
-  background-color: #f9c58e;
-  border-color: #f9c58e;
+  background-color: #ffa34a;
+  border-color: #ffa34a;
   color: #000;
 }
 

--- a/app/static/js/sales_form/autocomplete.js
+++ b/app/static/js/sales_form/autocomplete.js
@@ -15,8 +15,16 @@ export class Autocomplete {
   bind() {
     this.input.addEventListener('input', () => this.render());
     this.input.addEventListener('focus', () => this.render());
-    this.input.addEventListener('blur', () => setTimeout(() => this.hide(), 150));
+    this.list.addEventListener('mousedown', e => {
+      e.preventDefault();
+      this.onClick(e);
+    });
     this.list.addEventListener('click', e => this.onClick(e));
+    document.addEventListener('mousedown', e => {
+      if (!this.list.contains(e.target) && e.target !== this.input) {
+        this.hide();
+      }
+    });
     this.input.addEventListener('keydown', e => this.onKeyDown(e));
   }
 

--- a/app/templates/sales_form.html
+++ b/app/templates/sales_form.html
@@ -53,9 +53,9 @@
             <div id="vueltos-container"></div>
             <div id="descuentos-container"></div>
             <div class="d-flex gap-2 mt-3">
-              <button class="btn btn-secondary w-100" style="max-width: 180px;" id="add-payment">Añadir Medio</button>
-              <button class="btn btn-secondary w-100" style="max-width: 180px;" id="add-change">Añadir Vuelto</button>
-              <button class="btn btn-secondary w-100" style="max-width: 180px;" id="add-discount">Añadir Descuento</button>
+              <button class="btn btn-secondary w-100" style="max-width: 180px;" id="add-payment">+ Pago</button>
+              <button class="btn btn-secondary w-100" style="max-width: 180px;" id="add-change">+ Vuelto</button>
+              <button class="btn btn-secondary w-100" style="max-width: 180px;" id="add-discount">+ Descuento</button>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- keep autocomplete open on mousedown
- prevent blur until an item is selected
- rename add buttons and apply colors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840e00be57c83329d1361e880390a9c