### PR TITLE
Allow optional catalog in product edit form

### DIFF
--- a/app/static/js/movimientosDinero.js
+++ b/app/static/js/movimientosDinero.js
@@ -58,7 +58,7 @@ function renderTabla(data) {
 
           // Detección de enlaces
           let botonDetalleExtra = "";
-          const matchVenta = concepto.match(/Ingreso por venta\s*#(\d+)/i);
+          const matchVenta = concepto.match(/^V#(\d+)/i);
           const matchCompra = concepto.match(/Egreso por compra\s*#(\d+)/i);
 
           if (matchVenta) {

--- a/app/static/js/product_edit.js
+++ b/app/static/js/product_edit.js
@@ -75,6 +75,11 @@ async function cargarCatalogos() {
     catalogos = await res.json();
 
     catalogoSelect.innerHTML = "";
+    const optEmpty = document.createElement("option");
+    optEmpty.value = "";
+    optEmpty.textContent = "-- Sin catálogo --";
+    catalogoSelect.appendChild(optEmpty);
+
     for (const c of catalogos) {
       const option = document.createElement("option");
       option.value = c.id;
@@ -93,7 +98,7 @@ function abrirModal(p) {
   descripcionInput.value = p.descripcion;
   precioInput.value = p.precio_venta;
   stockInput.value = p.stock_actual;
-  catalogoSelect.value = p.catalogo_id;
+  catalogoSelect.value = p.catalogo_id ?? "";
   codigoInput.classList.remove("is-invalid");
   modal.show();
 }
@@ -103,12 +108,13 @@ async function handleFormSubmit(e) {
   overlay.style.display = "flex";
 
   const id = idInput.value;
+  const catalogoVal = catalogoSelect.value;
   const payload = {
     codigo_getoutside: codigoInput.value,
     descripcion: descripcionInput.value,
     precio_venta: parseFloat(precioInput.value),
     stock_actual: parseInt(stockInput.value),
-    catalogo_id: parseInt(catalogoSelect.value),
+    catalogo_id: catalogoVal === "" ? null : parseInt(catalogoVal),
   };
 
   const res = await fetch(`/productos/id/${id}`, {

--- a/app/templates/product_edit.html
+++ b/app/templates/product_edit.html
@@ -72,7 +72,9 @@
 
             <div class="mb-3">
               <label for="catalogo" class="form-label">Catálogo</label>
-              <select id="catalogo" class="form-select" required></select>
+              <select id="catalogo" class="form-select">
+                <option value="">-- Sin catálogo --</option>
+              </select>
             </div>
           </div>
           <div class="modal-footer d-flex justify-content-between">


### PR DESCRIPTION
## Summary
- allow selecting no catalog when editing a product
- show '-- Sin catálogo --' as first option
- handle empty catalog id in frontend logic
- include sale product codes in money movement concept and adjust JS regex

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f2f750dc83329cbc6afe100f50b4