### PR TITLE
Fix datetime precision

### DIFF
--- a/app/static/js/dashboard/dashboard_movimientos.js
+++ b/app/static/js/dashboard/dashboard_movimientos.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const serverDate = new Date(data.datetime);
       localISO = new Date(serverDate.getTime() - serverDate.getTimezoneOffset() * 60000)
         .toISOString()
-        .slice(0, 16);
+        .slice(0, 19);
       fechaInput.value = localISO;
     })
     .catch(err => {

--- a/app/static/js/sales_form/main.js
+++ b/app/static/js/sales_form/main.js
@@ -47,7 +47,7 @@ class SalesForm {
         const serverDate = new Date(data.datetime);
         const localISO = new Date(serverDate.getTime() - serverDate.getTimezoneOffset() * 60000)
           .toISOString()
-          .slice(0, 16);
+          .slice(0, 19);
         fechaInput.value = localISO;
       })
       .catch(err => {
@@ -345,7 +345,7 @@ class SalesForm {
         const serverDate = new Date(fechaData.datetime);
         const localISO = new Date(serverDate.getTime() - serverDate.getTimezoneOffset() * 60000)
           .toISOString()
-          .slice(0, 16);
+          .slice(0, 19);
         fechaInput.value = localISO;
       } catch (err) {
         console.error('Error obteniendo fecha del servidor', err);

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -108,7 +108,7 @@
           <div class="mb-3">
             <label for="fecha" class="form-label">Fecha</label>
             <div class="d-flex gap-2">
-              <input type="datetime-local" class="form-control" id="fecha" name="fecha" readonly required>
+              <input type="datetime-local" class="form-control" id="fecha" name="fecha" step="1" readonly required>
               <button type="button" id="btnModificarFecha" class="btn btn-outline-secondary">Editar fecha</button>
             </div>
           </div>

--- a/app/templates/sales_form.html
+++ b/app/templates/sales_form.html
@@ -27,7 +27,7 @@
       
       <div class="d-flex align-items-center gap-3">
         <label for="fecha-venta" class="form-label">Fecha</label>
-        <input type="datetime-local" id="fecha-venta" name="fecha" class="form-control" readonly style="max-width: 250px;">
+        <input type="datetime-local" id="fecha-venta" name="fecha" class="form-control" step="1" readonly style="max-width: 250px;">
         <button type="button" class="btn btn-outline-secondary btn-sm" id="editar-fecha">Edit</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- keep seconds in dashboard's datetime picker
- keep seconds in sale form datetime fields and after form reset
- allow seconds in datetime input fields

## Testing
- `node --check app/static/js/dashboard/dashboard_movimientos.js`
- `node --check app/static/js/sales_form/main.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68410162223c8332bcbff8fee8a7febc