### PR TITLE
Fix mobile file picker

### DIFF
--- a/app/templates/compra_add.html
+++ b/app/templates/compra_add.html
@@ -27,8 +27,8 @@
         </div>
         <div class="col-md-6">
           <label for="archivo" class="form-label">Archivo (opcional)</label>
-          <input type="file" class="form-control" id="archivo" name="archivo" accept="image/*,.pdf" capture="environment">
-          <div class="form-text">Podés seleccionar un archivo o tomar una foto.</div>
+          <input type="file" class="form-control" id="archivo" name="archivo">
+          <div class="form-text">Podés seleccionar cualquier archivo.</div>
         </div>
       </div>
       <div class="row mb-3">


### PR DESCRIPTION
## Summary
- allow any file type to be uploaded for purchases

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841c395ba148332a78c57d42db25ed0