### PR TITLE
Fix navigation and styling

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -23,7 +23,8 @@ body {
    ========================================================================== */
 .producto-block,
 .pago-block,
-.descuento-block {
+.descuento-block,
+.vuelto-block {
   border: 1px solid #ddd;
   border-radius: 8px;
   padding: 1rem;
@@ -364,7 +365,8 @@ input.is-invalid {
 /* === Bloques visuales para productos, descuentos y pagos === */
 .producto-block,
 .descuento-block,
-.pago-block {
+.pago-block,
+.vuelto-block {
   border: 1px solid #ddd;
   border-radius: 8px;
   padding: 1rem;

--- a/app/static/js/movimientosDinero.js
+++ b/app/static/js/movimientosDinero.js
@@ -65,7 +65,7 @@ function renderTabla(data) {
             const ventaId = matchVenta[1];
             botonDetalleExtra = `
               <div class="mt-4 text-end">
-                <a href="/ventas/${ventaId}" class="btn btn-primary btn-sm" target="_blank" rel="noopener">
+                <a href="/ventas/${ventaId}" class="btn btn-primary btn-sm">
                   Ver detalle de la venta
                 </a>
               </div>
@@ -74,7 +74,7 @@ function renderTabla(data) {
             const compraId = matchCompra[1];
             botonDetalleExtra = `
               <div class="mt-4 text-end">
-                <a href="/compras/detalle/${compraId}" class="btn btn-warning btn-sm" target="_blank" rel="noopener">
+                <a href="/compras/detalle/${compraId}" class="btn btn-warning btn-sm">
                   Ver detalle de la compra
                 </a>
               </div>

--- a/app/static/js/venta_detallada.js
+++ b/app/static/js/venta_detallada.js
@@ -6,12 +6,7 @@ function storeVentasFilters(paramsString = null) {
 
 // Vuelve al listado con los filtros anteriores si existen
 function goBackToFilteredList() {
-  const params = sessionStorage.getItem("lastVentasParams");
-  if (params) {
-    window.location.href = "/ventas/list?" + params;
-  } else {
-    window.location.href = "/ventas";
-  }
+  window.history.back();
 }
 
 // Construye los parámetros del formulario actual

--- a/app/templates/venta_detalle.html
+++ b/app/templates/venta_detalle.html
@@ -64,7 +64,7 @@
 
     <!-- Acciones -->
     <div class="d-flex justify-content-between mt-5">
-      <a href="#" class="btn btn-secondary" onclick="goBackToFilteredList()">← Volver al listado</a>
+      <a href="#" class="btn btn-secondary" onclick="window.history.back()">← Volver</a>
       <button class="btn btn-outline-primary" onclick="window.print()">Imprimir</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- make change blocks match the other blocks
- open money movement detail links in same tab
- make sale detail go back to the previous page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684376d53f68833290aa8a9667e73dde