### PR TITLE
Add improved search filter on stock and edit pages

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -571,3 +571,25 @@ select.form-select {
 #modal-message .alert {
   margin-bottom: 0;
 }
+
+/* ==========================================================================
+   Stock Overview Search
+   ========================================================================== */
+.stock-search {
+  max-width: 420px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.stock-search .form-control,
+.stock-search .input-group-text {
+  border: none;
+  padding-top: 0.6rem;
+  padding-bottom: 0.6rem;
+  font-size: 1.05rem;
+}
+
+.stock-search input::placeholder {
+  font-style: italic;
+}

--- a/app/static/js/stock_overview_filter.js
+++ b/app/static/js/stock_overview_filter.js
@@ -1,0 +1,17 @@
+// app/static/js/stock_overview_filter.js
+// Filtro dinámico para la tabla de stock
+
+document.addEventListener("DOMContentLoaded", () => {
+  const input = document.getElementById("stock-search");
+  const tbody = document.querySelector(".tabla-ordenable tbody");
+  if (!input || !tbody) return;
+
+  input.addEventListener("input", () => {
+    const value = input.value.trim().toLowerCase();
+    const rows = Array.from(tbody.querySelectorAll("tr"));
+    rows.forEach(row => {
+      const text = row.textContent.toLowerCase();
+      row.style.display = text.includes(value) ? "" : "none";
+    });
+  });
+});

--- a/app/templates/product_edit.html
+++ b/app/templates/product_edit.html
@@ -6,11 +6,18 @@
   <title>Edición de Productos</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
   <div class="container mt-5">
     <h1 class="mb-4 text-center">Editar Productos</h1>
+    <div class="d-flex justify-content-center mb-3">
+      <div class="input-group stock-search">
+        <span class="input-group-text bg-white border-end-0"><i class="bi bi-search"></i></span>
+        <input type="text" id="stock-search" class="form-control border-start-0" placeholder="Buscar" aria-label="Buscar">
+      </div>
+    </div>
     <div class="table-responsive">
       <table id="tabla-ordenable" class="table table-striped table-hover align-middle tabla-ordenable">
         <thead class="table-dark">
@@ -128,5 +135,6 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
   <script type="module" src="/static/js/product_edit.js" defer></script>
   <script src="https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js"></script>
+  <script src="/static/js/stock_overview_filter.js" defer></script>
 </body>
 </html>

--- a/app/templates/stock_overview.html
+++ b/app/templates/stock_overview.html
@@ -9,11 +9,18 @@
     rel="stylesheet"
     crossorigin="anonymous"
   >
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
   <div class="container mt-5">
     <h1 class="mb-4">Resumen de Stock de Productos</h1>
+    <div class="d-flex justify-content-center mb-3">
+      <div class="input-group stock-search">
+        <span class="input-group-text bg-white border-end-0"><i class="bi bi-search"></i></span>
+        <input type="text" id="stock-search" class="form-control border-start-0" placeholder="Buscar" aria-label="Buscar">
+      </div>
+    </div>
     <div class="table-responsive">
       <table class="table table-striped table-hover align-middle tabla-ordenable">
         <thead class="table-dark">
@@ -55,6 +62,7 @@
     crossorigin="anonymous" defer
   ></script>
   <script src="https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js"></script>
+  <script src="/static/js/stock_overview_filter.js" defer></script>
   <script>
     document.addEventListener("DOMContentLoaded", () => {
       new Tablesort(document.querySelector(".tabla-ordenable"));


### PR DESCRIPTION
## Summary
- make search field larger and reusable
- include same filter on product edit page
- update JS to handle dynamic rows

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68437fb3d1cc83329f641547f5a52d59