### PR TITLE
Update sales blocks layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -63,6 +63,17 @@ body {
   top: 0.25rem;
   right: 0.25rem;
 }
+.pago-block .btn-quitar-pago,
+.descuento-block .btn-quitar-descuento,
+.vuelto-block .btn-quitar-vuelto {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+}
+
+.amount-input {
+  max-width: 100px;
+}
 
 .vuelto-block {
   background-color: #ebe3f6;
@@ -79,15 +90,9 @@ body {
    ========================================================================== */
 .btn-quitar-producto,
 .btn-quitar-pago,
-.btn-quitar-descuento {
+.btn-quitar-descuento,
+.btn-quitar-vuelto {
   font-size: 1rem;
-  padding: 0.5rem 1rem;
-}
-
-.btn-quitar-pago,
-.btn-quitar-descuento {
-  align-self: flex-end;
-  margin-bottom: 0.25rem;
 }
 
 /* ==========================================================================

--- a/app/static/js/sales_form/changeBlock.js
+++ b/app/static/js/sales_form/changeBlock.js
@@ -19,20 +19,18 @@ export class ChangeBlock {
       .map(m => `<option value="${m.id}" data-currency="${m.currency}">${m.name} - ${m.currency_label} ${m.currency}</option>`)
       .join('');
     const div = document.createElement('div');
-    div.className = 'vuelto-block border rounded p-3 mb-3';
+    div.className = 'vuelto-block border rounded p-3 mb-3 position-relative';
     div.innerHTML = `
-      <div class="mb-2">
-        <label class="form-label">Medio del Vuelto</label>
-        <select name="payment_method_id" class="form-select">${options}</select>
+      <button type="button" class="btn-close btn-sm btn-quitar-vuelto position-absolute top-0 end-0 m-2" aria-label="Quitar"></button>
+      <div class="row mb-1">
+        <div class="col"><label class="form-label">Medio del Vuelto</label></div>
       </div>
-      <div class="row mb-2">
+      <div class="row align-items-end g-2">
         <div class="col">
-          <label class="form-label">Monto</label>
-          <input type="number" name="amount" class="form-control" step="0.01">
+          <select name="payment_method_id" class="form-select">${options}</select>
         </div>
-        <div class="col-auto d-flex flex-column justify-content-end">
-          <label class="form-label invisible">Quitar</label>
-          <button class="btn btn-danger btn-quitar-vuelto">Quitar</button>
+        <div class="col-auto">
+          <input type="number" name="amount" class="form-control amount-input" step="0.01">
         </div>
       </div>`;
     return div;

--- a/app/static/js/sales_form/discountBlock.js
+++ b/app/static/js/sales_form/discountBlock.js
@@ -22,20 +22,18 @@ export class DiscountBlock {
   /** Genera el HTML del bloque */
   render() {
     const div = document.createElement('div');
-    div.className = 'descuento-block border rounded p-3 mb-3';
+    div.className = 'descuento-block border rounded p-3 mb-3 position-relative';
     div.innerHTML = `
-      <div class="mb-2">
-        <label class="form-label">Concepto de Descuento</label>
-        <input type="text" name="concepto" class="form-control">
+      <button type="button" class="btn-close btn-sm btn-quitar-descuento position-absolute top-0 end-0 m-2" aria-label="Quitar"></button>
+      <div class="row mb-1">
+        <div class="col"><label class="form-label">Concepto</label></div>
       </div>
-      <div class="row mb-2">
+      <div class="row align-items-end g-2">
         <div class="col">
-          <label class="form-label">Monto</label>
-          <input type="number" name="amount" class="form-control" step="0.01">
+          <input type="text" name="concepto" class="form-control">
         </div>
-        <div class="col-auto d-flex flex-column justify-content-end">
-          <label class="form-label invisible">Quitar</label>
-          <button class="btn btn-danger btn-quitar-descuento">Quitar</button>
+        <div class="col-auto">
+          <input type="number" name="amount" class="form-control amount-input" step="0.01">
         </div>
       </div>
     `;

--- a/app/static/js/sales_form/paymentBlock.js
+++ b/app/static/js/sales_form/paymentBlock.js
@@ -22,20 +22,18 @@ export class PaymentBlock {
       .map(m => `<option value="${m.id}" data-currency="${m.currency}">${m.name} - ${m.currency_label} ${m.currency}</option>`)
       .join('');
     const div = document.createElement('div');
-    div.className = 'pago-block border rounded p-3 mb-3';
+    div.className = 'pago-block border rounded p-3 mb-3 position-relative';
     div.innerHTML = `
-      <div class="mb-2">
-        <label class="form-label">Medio de Pago</label>
-        <select name="payment_method_id" class="form-select">${options}</select>
+      <button type="button" class="btn-close btn-sm btn-quitar-pago position-absolute top-0 end-0 m-2" aria-label="Quitar"></button>
+      <div class="row mb-1">
+        <div class="col"><label class="form-label">Medio de Pago</label></div>
       </div>
-      <div class="row mb-2">
+      <div class="row align-items-end g-2">
         <div class="col">
-          <label class="form-label">Monto</label>
-          <input type="number" name="amount" class="form-control" step="0.01">
+          <select name="payment_method_id" class="form-select">${options}</select>
         </div>
-        <div class="col-auto d-flex flex-column justify-content-end">
-          <label class="form-label invisible">Quitar</label>
-          <button class="btn btn-danger btn-quitar-pago">Quitar</button>
+        <div class="col-auto">
+          <input type="number" name="amount" class="form-control amount-input" step="0.01">
         </div>
       </div>
     `;


### PR DESCRIPTION
## Summary
- switch payment, discount, and change blocks to use close icon
- display those blocks in two lines with narrow amount field
- remove "Monto" labels which overlapped the close button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68477eeeb21483329a11d745c3a02340