### PR TITLE
Refine sales summary modal

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -292,11 +292,66 @@ body {
   font-family: 'Courier New', monospace;
   font-size: 1rem;
   line-height: 1.5;
-  white-space: pre-wrap;
   background-color: #f8f9fa;
   padding: 1rem;
   border: 1px dashed #ccc;
   border-radius: 6px;
+}
+
+.ticket-line {
+  display: flex;
+  justify-content: space-between;
+}
+
+.ticket-indent {
+  padding-left: 1.5rem;
+}
+
+.ticket-blue {
+  color: #005b96;
+}
+
+.ticket-blue-light {
+  color: #5bc0de;
+  font-style: italic;
+}
+
+.ticket-orange {
+  color: #ff6600;
+}
+
+.ticket-orange-light {
+  color: #ffae6d;
+  font-style: italic;
+}
+
+.ticket-green {
+  /* Green tone more vivid for better contrast */
+  color: #28a745;
+}
+
+.ticket-green-light {
+  color: #198754;
+  font-style: italic;
+}
+
+.ticket-purple {
+  color: #4b0082;
+}
+
+.ticket-purple-light {
+  color: #a671ff;
+  font-style: italic;
+}
+
+.ticket-divider {
+  border-top: 1px dashed #000;
+  margin: 0.5rem 0;
+}
+
+.ticket-total {
+  font-size: 1.2rem;
+  font-weight: bold;
 }
 
 #total-venta,

--- a/app/templates/sales_form.html
+++ b/app/templates/sales_form.html
@@ -118,10 +118,9 @@
       <div class="modal-content">
         <div class="modal-header">
           <div id="modal-message" class="w-100"></div>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
         <div class="modal-body">
-          <pre id="resumen-texto" class="mb-0" style="white-space: pre-wrap; font-family: monospace;"></pre>
+          <div id="resumen-texto" class="ticket"></div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Editar</button>


### PR DESCRIPTION
## Summary
- remove close button from summary modal header
- adjust paid total color to a brighter green

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684836d0221483329f216dd4c8c6e5f9