### PR TITLE
Improve filter popup behavior

### DIFF
--- a/app/crud/dinero.py
+++ b/app/crud/dinero.py
@@ -94,3 +94,30 @@ def get_movimiento_by_id(db: Session, movimiento_id: int) -> MovimientoDinero:
         raise MovimientoNoRegistrado(f"Movimiento con ID {movimiento_id} no encontrado.")
 
     return movimiento
+
+
+def filtrar_movimientos(
+    db: Session,
+    limit: int | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    tipo: TipoMovimientoDinero | None = None,
+    concepto: str | None = None,
+) -> list[MovimientoDinero]:
+    """Aplica filtros opcionales y devuelve los movimientos de dinero."""
+
+    query = db.query(MovimientoDinero).options(joinedload(MovimientoDinero.metodo_pago))
+
+    if start:
+        query = query.filter(MovimientoDinero.fecha >= start)
+    if end:
+        query = query.filter(MovimientoDinero.fecha <= end)
+    if tipo:
+        query = query.filter(MovimientoDinero.tipo == tipo)
+    if concepto:
+        query = query.filter(MovimientoDinero.concepto.ilike(f"%{concepto}%"))
+
+    query = query.order_by(MovimientoDinero.fecha.desc())
+    if limit:
+        query = query.limit(limit)
+    return query.all()

--- a/app/routers/movimientos_dinero.py
+++ b/app/routers/movimientos_dinero.py
@@ -1,8 +1,16 @@
-from fastapi import APIRouter, Request, Depends, status
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Request, Depends, status, Query
 from fastapi.responses import HTMLResponse, JSONResponse
 from sqlalchemy.orm import Session
 
-from app.crud.dinero import listar_movimientos, crear_y_guardar_movimiento, get_movimiento_by_id
+from app.crud.dinero import (
+    listar_movimientos,
+    crear_y_guardar_movimiento,
+    get_movimiento_by_id,
+    filtrar_movimientos,
+)
 from app.schemas.dinero import MovimientoDineroCreate, MovimientoDineroOut
 from app.models.dinero import TipoMovimientoDinero, MovimientoDinero
 from app.core.deps import get_db
@@ -22,9 +30,29 @@ def ver_movimientos_page(request: Request, db: Session = Depends(get_db)):
 # API JSON: últimos N movimientos, ordenados por fecha
 @router.get("/api/movimientos-dinero", response_model=list[MovimientoDineroOut])
 def listar_movimientos_dinero(
-    limit: int = DEFAULT_MOVIMIENTOS_LIMIT,  # 👈 Usás la constante como valor por defecto
+    limit: int = DEFAULT_MOVIMIENTOS_LIMIT,
+    start: Optional[str] = Query(None),
+    end: Optional[str] = Query(None),
+    tipo: Optional[TipoMovimientoDinero] = Query(None),
+    ventas: bool = False,
+    concepto: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
+    start_dt = datetime.fromisoformat(start) if start else None
+    end_dt = datetime.fromisoformat(end) if end else None
+
+    if ventas:
+        concepto = "V#"
+
+    if any([start_dt, end_dt, tipo, concepto]):
+        return filtrar_movimientos(
+            db=db,
+            limit=None,
+            start=start_dt,
+            end=end_dt,
+            tipo=tipo,
+            concepto=concepto,
+        )
     return listar_movimientos(db, limit=limit)
 
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -210,6 +210,31 @@ body {
   z-index: 9999;
 }
 
+.modal-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1055;
+}
+
+.btn-filtro {
+  background: linear-gradient(#ffa94d, #ff7f0e);
+  border: none;
+  color: #fff;
+  box-shadow: 0 4px 0 #c66b00;
+}
+
+.btn-filtro:active {
+  box-shadow: 0 1px 0 #c66b00;
+  transform: translateY(3px);
+}
+
 /* ==========================================================================
    Autocomplete List — estilos alternos para distinguir filas
    ========================================================================== */

--- a/app/templates/movimientos_dinero.html
+++ b/app/templates/movimientos_dinero.html
@@ -10,11 +10,11 @@
 <body>
   <div class="container mt-5">
     <h2 class="mb-4 text-center">Movimientos de Dinero</h2>
-    <div class="d-flex justify-content-end mb-3">
-      <a href="/tenencias/" class="btn btn-primary btn-modern">
-        Ir a Tenencias
-      </a>
+    <div class="d-flex justify-content-between align-items-center">
+      <button type="button" class="btn btn-filtro btn-sm" id="btnFiltro">Filtrar</button>
+      <a href="/tenencias/" class="btn btn-primary btn-modern">Ir a Tenencias</a>
     </div>
+    <p id="infoConsulta" class="small text-muted mt-2 mb-3">Últimos 30 movimientos de dinero</p>
     <div class="tabla-scroll">
       <table class="table table-striped tabla-ordenable align-middle" id="tabla-movimientos">
         <thead>
@@ -30,10 +30,59 @@
         </tbody>
       </table>
     </div>
-    <div class="text-center mt-4">
-      <a href="/" class="text-muted">&larr; Volver al Dashboard</a>
+  <div class="text-center mt-4">
+    <a href="/" class="text-muted">&larr; Volver al Dashboard</a>
+  </div>
+</div>
+
+<!-- Modal Filtro -->
+<div class="modal fade" id="modalFiltro" tabindex="-1" aria-labelledby="modalFiltroLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div id="filtroOverlay" class="modal-overlay">
+        <div class="spinner-border text-primary" role="status"></div>
+      </div>
+      <div class="modal-header">
+        <h5 class="modal-title" id="modalFiltroLabel">Filtrar Movimientos</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <form id="filtroForm">
+        <div class="modal-body">
+          <div class="d-flex justify-content-center gap-2 mb-3">
+            <button type="button" class="btn btn-outline-primary btn-sm" id="btnSemana">Última semana</button>
+            <button type="button" class="btn btn-outline-primary btn-sm" id="btnMes">Último mes</button>
+          </div>
+          <div class="row g-2 mb-3">
+            <div class="col">
+              <label for="fechaDesde" class="form-label">Fecha desde</label>
+              <input type="date" class="form-control" id="fechaDesde">
+            </div>
+            <div class="col">
+              <label for="fechaHasta" class="form-label">Fecha hasta</label>
+              <input type="date" class="form-control" id="fechaHasta">
+            </div>
+          </div>
+          <div class="mb-3">
+            <label for="tipoFiltro" class="form-label">Tipo</label>
+            <select id="tipoFiltro" class="form-select">
+              <option value="">Todos</option>
+              <option value="INGRESO">Ingresos</option>
+              <option value="EGRESO">Egresos</option>
+              <option value="VENTA">Ventas</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="conceptoBuscar" class="form-label">Concepto</label>
+            <input type="text" class="form-control" id="conceptoBuscar" placeholder="Buscar concepto">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-primary">Aplicar</button>
+        </div>
+      </form>
     </div>
   </div>
+</div>
 
 
   


### PR DESCRIPTION
## Summary
- allow `filtrar_movimientos` to return all records
- remove limit when filtering in API route
- style `Filtrar` button and add overlay spinner in modal
- show filter summary label above the table
- reset filters after querying and display loading overlay

## Testing
- `python -m py_compile app/crud/dinero.py app/routers/movimientos_dinero.py`

------
https://chatgpt.com/codex/tasks/task_e_6852df27af0c83328b4d64fb9d006ca3