### PR TITLE
Fix edit product form to send multipart data

### DIFF
--- a/app/static/js/product_edit.js
+++ b/app/static/js/product_edit.js
@@ -109,18 +109,19 @@ async function handleFormSubmit(e) {
 
   const id = idInput.value;
   const catalogoVal = catalogoSelect.value;
-  const payload = {
-    codigo_getoutside: codigoInput.value,
-    descripcion: descripcionInput.value,
-    precio_venta: parseFloat(precioInput.value),
-    stock_actual: parseInt(stockInput.value),
-    catalogo_id: catalogoVal === "" ? null : parseInt(catalogoVal),
-  };
+  const formData = new FormData();
+  formData.append("codigo_getoutside", codigoInput.value);
+  formData.append("descripcion", descripcionInput.value);
+  formData.append("precio_venta", parseFloat(precioInput.value));
+  formData.append("stock_actual", parseInt(stockInput.value));
+  formData.append(
+    "catalogo_id",
+    catalogoVal === "" ? "" : parseInt(catalogoVal)
+  );
 
   const res = await fetch(`/productos/id/${id}`, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload)
+    body: formData,
   });
 
   overlay.style.display = "none";


### PR DESCRIPTION
## Summary
- send `multipart/form-data` when updating products from the edit UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686188ebc96c8332a92fc701e3e2db4a