### PR TITLE
Add persistent Postgres for dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ app/static/uploads/*
 
 # Node
 node_modules/
+data/*
+!data/db/
+!data/db/.gitkeep

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simple web app to manage product catalog, stock, sales, payments and basic metri
    # edit .env: DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME, SECRET_KEY
    ```
 
-2. Build & run with Docker Compose:
+2. Build & run with Docker Compose (includes a local Postgres container):
    ```bash
    make up        # builds images and starts containers
    ```
@@ -22,6 +22,10 @@ Simple web app to manage product catalog, stock, sales, payments and basic metri
    - Admin → `/admin`
    - Consults → `/consultas`
    - Metrics → `/metrics`
+
+Database files are stored under `./data/db`, so your data persists even if you
+rebuild the containers.  Code is mounted with live reload so changes to `.py`
+and template files are reflected immediately.
 
 4. To tear down (including DB data):
    ```bash

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,11 +8,12 @@ services:
       - TZ=Pacific/Auckland
     volumes:
       - .:/app
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/GetOutside_produccion/Uploads:/app/static/uploads
+      - ./app/static/uploads:/app/static/uploads
     networks:
       - getoutside-net
       - nginx_net
-    depends_on: []
+      depends_on:
+        - db
     restart: unless-stopped 
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,22 @@
 version: "3.9"
 
 services:
+  db:
+    image: postgres:15
+    env_file:
+      - .env.dev
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+      TZ: Pacific/Auckland
+      PGTZ: Pacific/Auckland
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
+    networks:
+      - getoutside-net
+    restart: unless-stopped
+
   web:
     build: .
     ports:
@@ -11,12 +27,13 @@ services:
       - TZ=Pacific/Auckland
     volumes:
       - .:/app
-      - /srv/dev-disk-by-uuid-1735d6ab-2a75-4dc4-91a9-b81bb3fda73d/Servicios/GetOutside_produccion/Uploads:/app/static/uploads
+      - ./app/static/uploads:/app/static/uploads
     networks:
       - getoutside-net
       - nginx_net
-    depends_on: []
-    restart: unless-stopped 
+    depends_on:
+      - db
+    restart: unless-stopped
 
 networks:
   getoutside-net:


### PR DESCRIPTION
## Summary
- include a Postgres container in `docker-compose.yml` for development
- mount uploads directory and depend on the db service
- match override file with new paths and dependency
- persist database files in `./data/db`
- document new workflow in README
- ignore `data` directory and keep `.gitkeep` for tracked path

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6878ec5a474083329ea020c39ef40c41