### PR TITLE
Enable photo updates in product editor

### DIFF
--- a/app/crud/inventario.py
+++ b/app/crud/inventario.py
@@ -40,7 +40,11 @@ def create_producto(
 
 
 def update_producto_completo(
-    db: Session, producto_id: int, data: ProductoCreate, foto: UploadFile | None = None
+    db: Session,
+    producto_id: int,
+    data: ProductoCreate,
+    foto: UploadFile | None = None,
+    delete_foto: bool = False,
 ) -> Producto:
     """
     Actualiza completamente un producto existente:
@@ -79,7 +83,16 @@ def update_producto_completo(
         dest_path = os.path.join(PRODUCT_PHOTOS_DIR, filename)
         with open(dest_path, "wb") as out:
             out.write(foto.file.read())
+        if prod.foto_filename and prod.foto_filename != filename:
+            old_path = os.path.join(PRODUCT_PHOTOS_DIR, prod.foto_filename)
+            if os.path.exists(old_path):
+                os.remove(old_path)
         prod.foto_filename = filename
+    elif delete_foto and prod.foto_filename:
+        old_path = os.path.join(PRODUCT_PHOTOS_DIR, prod.foto_filename)
+        if os.path.exists(old_path):
+            os.remove(old_path)
+        prod.foto_filename = None
 
     # Guardar cambios
     db.commit()

--- a/app/routers/productos.py
+++ b/app/routers/productos.py
@@ -189,6 +189,7 @@ async def actualizar_producto_completo(
 
     stock_actual: int = Form(...),
     foto: UploadFile = File(None),
+    eliminar_foto: bool = Form(False),
     db: Session = Depends(get_db),
 ):
     """
@@ -206,6 +207,6 @@ async def actualizar_producto_completo(
             costo_produccion=costo_produccion,
             stock_actual=stock_actual,
         )
-        return update_producto_completo(db, producto_id, data, foto)
+        return update_producto_completo(db, producto_id, data, foto, eliminar_foto)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/app/static/js/product_edit.js
+++ b/app/static/js/product_edit.js
@@ -3,7 +3,10 @@
 let productos = [];
 let catalogos = [];
 
-let modal, form, idInput, codigoInput, descripcionInput, precioInput, costoInput, stockInput, catalogoSelect, btnEliminar;
+let modal, form,
+  idInput, codigoInput, descripcionInput, precioInput, costoInput,
+  stockInput, catalogoSelect, fotoInput, fotoActual, eliminarFotoCheckbox,
+  btnEliminar;
 let modalConfirmar, modalError, overlay, confirmarEliminarBtn;
 
 let idPendienteEliminar = null;
@@ -24,6 +27,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   costoInput = document.getElementById("costo");
   stockInput = document.getElementById("stock");
   catalogoSelect = document.getElementById("catalogo");
+  fotoInput = document.getElementById("foto");
+  fotoActual = document.getElementById("foto-actual");
+  eliminarFotoCheckbox = document.getElementById("eliminar-foto");
   btnEliminar = document.getElementById("btn-eliminar");
   confirmarEliminarBtn = document.getElementById("confirmar-eliminar");
 
@@ -102,6 +108,16 @@ function abrirModal(p) {
   stockInput.value = p.stock_actual;
   catalogoSelect.value = p.catalogo_id ?? "";
   codigoInput.classList.remove("is-invalid");
+  fotoInput.value = "";
+  eliminarFotoCheckbox.checked = false;
+  if (p.foto_filename) {
+    fotoActual.src = `/static/uploads/products_photos/${p.foto_filename}`;
+    fotoActual.style.display = "block";
+    eliminarFotoCheckbox.disabled = false;
+  } else {
+    fotoActual.style.display = "none";
+    eliminarFotoCheckbox.disabled = true;
+  }
   modal.show();
 }
 
@@ -123,6 +139,11 @@ async function handleFormSubmit(e) {
     "catalogo_id",
     catalogoVal === "" ? "" : parseInt(catalogoVal)
   );
+
+  if (fotoInput.files[0]) {
+    formData.append("foto", fotoInput.files[0]);
+  }
+  formData.append("eliminar_foto", eliminarFotoCheckbox.checked ? "true" : "false");
 
   const res = await fetch(`/productos/id/${id}`, {
     method: "PUT",

--- a/app/templates/product_edit.html
+++ b/app/templates/product_edit.html
@@ -88,6 +88,20 @@
                 <option value="">-- Sin catálogo --</option>
               </select>
             </div>
+
+            <div class="mb-3">
+              <label class="form-label">Foto actual</label><br>
+              <img id="foto-actual" src="" alt="Sin foto" class="img-thumbnail mb-2" style="max-height: 200px; display:none;">
+              <div class="form-check mt-2">
+                <input class="form-check-input" type="checkbox" id="eliminar-foto">
+                <label class="form-check-label" for="eliminar-foto">Eliminar foto actual</label>
+              </div>
+            </div>
+
+            <div class="mb-3">
+              <label for="foto" class="form-label">Nueva foto</label>
+              <input type="file" class="form-control" id="foto" accept="image/*" capture="environment">
+            </div>
           </div>
           <div class="modal-footer d-flex justify-content-between">
             <button type="button" id="btn-eliminar" class="btn btn-danger">Eliminar</button>


### PR DESCRIPTION
## Summary
- add current photo preview and new photo input to edit modal
- handle file selection and deletion in product edit JS
- support optional `eliminar_foto` when updating product
- allow photo removal and replacement on the backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3dc03cc88332a5711e6039a00a6b