### PR TITLE
Update main database init order

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,8 +34,8 @@ from .routers import (
 )
 
 # Crear tablas en base de datos
-_ensure_extra_columns()
 Base.metadata.create_all(bind=engine)
+_ensure_extra_columns()
 
 app = FastAPI(title="GetOutside Stock API")
 


### PR DESCRIPTION
## Summary
- create tables in the database before running the extra column helper

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_687d4fe0bca883329e0bcc2825464270