### PR TITLE
Add ranking placeholder template

### DIFF
--- a/app/templates/ranking_placeholder.html
+++ b/app/templates/ranking_placeholder.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Ranking</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+  <div class="container mt-5">
+    <h1>Página de Ranking</h1>
+    <p>Esta sección está en construcción.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic ranking placeholder template so `/ranking` works

## Testing
- `python - <<'EOF'
from fastapi import FastAPI
from app.routers import ranking
from fastapi.testclient import TestClient
app = FastAPI(); app.include_router(ranking.router); client=TestClient(app); resp = client.get('/ranking/'); print('status', resp.status_code); print('contains placeholder', 'Ranking' in resp.text)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687d957ee8dc833285cdbfa770106407