### PR TITLE
Ensure ranking placeholder available

### DIFF
--- a/app/templates/ranking_placeholder.html
+++ b/app/templates/ranking_placeholder.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container mt-5">
     <h1>Página de Ranking</h1>
-    <p>Esta sección está en construcción.</p>
+    <p>Sección de ranking próximamente disponible.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- tweak placeholder text in `ranking_placeholder.html`
- confirm router uses this template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uvicorn app.main:app --port 8000 --reload` & `curl -i http://127.0.0.1:8000/ranking/`

------
https://chatgpt.com/codex/tasks/task_e_687d97f13340833280dbfa9756856705