### PR TITLE
Add user settings menu and default admin

### DIFF
--- a/app/crud/users.py
+++ b/app/crud/users.py
@@ -50,3 +50,27 @@ def delete_user(db: Session, user_id: int) -> bool:
     db.delete(user)
     db.commit()
     return True
+
+
+def update_user(
+    db: Session,
+    user_id: int,
+    first_name: str,
+    last_name: str,
+    email: str,
+    password: Optional[str] = None,
+) -> Optional[User]:
+    user = get_user(db, user_id)
+    if not user:
+        return None
+    # check email uniqueness if changed
+    if user.email != email and get_user_by_email(db, email):
+        raise ValueError("Email ya registrado")
+    user.first_name = first_name
+    user.last_name = last_name
+    user.email = email
+    if password:
+        user.password_hash = bcrypt.hash(password)
+    db.commit()
+    db.refresh(user)
+    return user

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -12,6 +12,8 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
+    first_name = Column(String, nullable=True)
+    last_name = Column(String, nullable=True)
     email = Column(String, unique=True, nullable=False, index=True)
     password_hash = Column(String, nullable=False)
     role = Column(PgEnum(UserRole, name="userrole", native_enum=True), nullable=False, default=UserRole.VENDEDOR)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -16,6 +16,11 @@
 <body>
   <div class="container py-3 px-2">
 
+    <!-- Botón menú -->
+    <button class="btn btn-link" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasMenu" aria-controls="offcanvasMenu">
+      <i class="bi bi-list fs-3"></i>
+    </button>
+
     <!-- 🔷 TÍTULO PRINCIPAL -->
     <h2 class="text-center mb-4">Dashboard GetOutside</h2>
     
@@ -140,6 +145,18 @@
           </button>
         </div>
       </form>
+    </div>
+  </div>
+
+  <!-- Offcanvas Menu -->
+  <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvasMenu" aria-labelledby="offcanvasMenuLabel">
+    <div class="offcanvas-header">
+      <h5 class="offcanvas-title" id="offcanvasMenuLabel">Menú</h5>
+      <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body d-grid gap-2">
+      <a href="/config" class="btn btn-outline-primary">Config</a>
+      <a href="/logout" class="btn btn-outline-danger">Log out</a>
     </div>
   </div>
 

--- a/app/templates/user_config.html
+++ b/app/templates/user_config.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Configuración de Usuario</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+  <div class="container" style="max-width: 500px;">
+    <h2 class="text-center my-4">Config Usuario</h2>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <form method="post" action="/config" class="d-flex flex-column gap-3">
+      <input type="text" name="first_name" class="form-control" placeholder="Nombre" value="{{ user.first_name or '' }}">
+      <input type="text" name="last_name" class="form-control" placeholder="Apellido" value="{{ user.last_name or '' }}">
+      <input type="email" name="email" class="form-control" placeholder="Email" value="{{ user.email }}" required>
+      <input type="password" name="password" class="form-control" placeholder="Nueva contraseña (opcional)">
+      <button type="submit" class="btn btn-primary">Guardar</button>
+    </form>
+    <div class="text-center mt-3">
+      <a href="/dashboard" class="text-muted">&larr; Volver</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add first and last name columns to user model
- auto-create missing user columns and default admin user
- support updating user data
- provide `/config` form to change user info
- add menu in dashboard linking to Config and Log out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687db8d71494833284c481bc19d446e6