### PR TITLE
Fix user menu style

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -697,3 +697,16 @@ select.form-select {
 #total-productos {
   font-size: 1.5rem;  /* Ajustá el valor a gusto (ej: 2rem, 32px, etc.) */
 }
+
+/* ==========================================================================
+   User Menu Links
+   ========================================================================== */
+.user-menu-link {
+  color: #6c757d; /* professional grey */
+  text-decoration: none;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+.user-menu-link:hover {
+  color: #495057;
+}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -154,9 +154,9 @@
       <h5 class="offcanvas-title" id="offcanvasMenuLabel">Menú</h5>
       <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
-    <div class="offcanvas-body d-grid gap-2">
-      <a href="/config" class="btn btn-outline-primary">Config</a>
-      <a href="/logout" class="btn btn-outline-danger">Log out</a>
+    <div class="offcanvas-body d-flex flex-column gap-2">
+      <a href="/config" class="user-menu-link">Config</a>
+      <a href="/logout" class="user-menu-link">Log out</a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- change user menu items from buttons to links
- style user menu links in professional grey

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687dbbb8a67c8332a5de5f27a842dd42