### PR TITLE
Update user admin UI

### DIFF
--- a/app/static/js/manage_users.js
+++ b/app/static/js/manage_users.js
@@ -1,0 +1,74 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const userSelect = document.getElementById('userSelect');
+  const roleSelect = document.getElementById('roleSelect');
+  const modifyBtn = document.getElementById('modifyBtn');
+  const deleteBtn = document.getElementById('deleteBtn');
+  const overlay = document.getElementById('overlay');
+
+  const modifyModal = new bootstrap.Modal(document.getElementById('modifyModal'));
+  const deleteModal = new bootstrap.Modal(document.getElementById('deleteModal'));
+
+  const modifyBody = document.getElementById('modifyModalBody');
+  const deleteBody = document.getElementById('deleteModalBody');
+  const confirmModifyBtn = document.getElementById('confirmModifyBtn');
+  const confirmDeleteBtn = document.getElementById('confirmDeleteBtn');
+
+  const getSelectedEmail = () => {
+    const opt = userSelect.options[userSelect.selectedIndex];
+    return opt ? (opt.dataset.email || opt.textContent) : '';
+  };
+
+  modifyBtn.addEventListener('click', () => {
+    modifyBody.textContent = `CONFIRMA QUE QUIERE MODIFICAR EL ROL PARA EL USUARIO: ${getSelectedEmail()}`;
+    confirmModifyBtn.disabled = false;
+    confirmModifyBtn.textContent = 'Modificar';
+    modifyModal.show();
+  });
+
+  confirmModifyBtn.addEventListener('click', async () => {
+    confirmModifyBtn.disabled = true;
+    confirmModifyBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Modificando...`;
+    overlay.style.display = 'flex';
+    try {
+      const res = await fetch('/admin/users/change', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ user_id: userSelect.value, role: roleSelect.value })
+      });
+      if (res.redirected) {
+        window.location.href = res.url;
+      } else {
+        window.location.reload();
+      }
+    } catch (err) {
+      window.location.reload();
+    }
+  });
+
+  deleteBtn.addEventListener('click', () => {
+    deleteBody.textContent = `ELIMINAR EL USUARIO: ${getSelectedEmail()} DEL SISTEMA?`;
+    confirmDeleteBtn.disabled = false;
+    confirmDeleteBtn.textContent = 'Eliminar';
+    deleteModal.show();
+  });
+
+  confirmDeleteBtn.addEventListener('click', async () => {
+    confirmDeleteBtn.disabled = true;
+    confirmDeleteBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Eliminando...`;
+    overlay.style.display = 'flex';
+    try {
+      const res = await fetch('/admin/users/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ user_id: userSelect.value })
+      });
+      if (res.redirected) {
+        window.location.href = res.url;
+      } else {
+        window.location.reload();
+      }
+    } catch (err) {
+      window.location.reload();
+    }
+  });
+});

--- a/app/static/js/user_config.js
+++ b/app/static/js/user_config.js
@@ -2,6 +2,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const deleteBtn = document.getElementById("deleteAccountBtn");
   const confirmBtn = document.getElementById("confirmDeleteAccountBtn");
   const modal = new bootstrap.Modal(document.getElementById("deleteAccountModal"));
+  const overlay = document.getElementById("overlay");
 
   if (deleteBtn) {
     deleteBtn.addEventListener("click", () => {
@@ -12,22 +13,23 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (confirmBtn) {
-    confirmBtn.addEventListener("click", async () => {
-      confirmBtn.disabled = true;
-      confirmBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Eliminando...`;
-      try {
-        const res = await fetch("/config/delete", {
-          method: "POST",
-          credentials: "same-origin",
-        });
-        if (res.redirected) {
-          window.location.href = res.url;
-        } else {
+      confirmBtn.addEventListener("click", async () => {
+        confirmBtn.disabled = true;
+        confirmBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Eliminando...`;
+        if (overlay) overlay.style.display = "flex";
+        try {
+          const res = await fetch("/config/delete", {
+            method: "POST",
+            credentials: "same-origin",
+          });
+          if (res.redirected) {
+            window.location.href = res.url;
+          } else {
+            window.location.href = "/login";
+          }
+        } catch (err) {
           window.location.href = "/login";
         }
-      } catch (err) {
-        window.location.href = "/login";
-      }
-    });
+      });
   }
 });

--- a/app/templates/manage_users.html
+++ b/app/templates/manage_users.html
@@ -10,39 +10,77 @@
 <body>
   <div class="container mt-5" style="max-width:500px;">
     <h2 class="text-center mb-4">Usuarios</h2>
-    <form method="post" action="/admin/users/change" class="mb-3">
-      <div class="mb-3">
-        <label class="form-label">Usuario</label>
-        <select name="user_id" class="form-select">
-          {% for u in users %}
-          <option value="{{ u.id }}">{{ u.email }} ({{ u.role.value }})</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="mb-3">
-        <label class="form-label">Rol</label>
-        <select name="role" class="form-select">
-          {% for r in roles %}
-          <option value="{{ r.value }}">{{ r.value }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <button type="submit" class="btn btn-primary">Modificar</button>
-    </form>
-    <form method="post" action="/admin/users/delete" class="mb-3">
-      <div class="mb-3">
-        <label class="form-label">Eliminar usuario</label>
-        <select name="user_id" class="form-select">
-          {% for u in users %}
-          <option value="{{ u.id }}">{{ u.email }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <button type="submit" class="btn btn-danger">Eliminar</button>
-    </form>
+
+    <div class="mb-3">
+      <label class="form-label">Usuario</label>
+      <select id="userSelect" class="form-select">
+        {% for u in users %}
+        <option value="{{ u.id }}" data-email="{{ u.email }}">{{ u.email }} ({{ u.role.value }})</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Rol</label>
+      <select id="roleSelect" class="form-select">
+        {% for r in roles %}
+        <option value="{{ r.value }}">{{ r.value }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div class="d-flex mb-3">
+      <button id="modifyBtn" class="btn btn-primary flex-grow-1 me-2">Modificar</button>
+      <button id="deleteBtn" class="btn btn-danger flex-grow-1 ms-2">Eliminar</button>
+    </div>
+
     <div class="text-center">
       <a href="/admin" class="text-muted">&larr; Volver</a>
     </div>
   </div>
+
+  <!-- Overlay Spinner -->
+  <div id="overlay">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Procesando...</span>
+    </div>
+  </div>
+
+  <!-- Modal Confirmar Modificación -->
+  <div class="modal fade" id="modifyModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Confirmar modificación</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body" id="modifyModalBody"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="button" id="confirmModifyBtn" class="btn btn-primary">Modificar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal Confirmar Eliminación -->
+  <div class="modal fade" id="deleteModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Confirmar eliminación</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+        </div>
+        <div class="modal-body" id="deleteModalBody"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="button" id="confirmDeleteBtn" class="btn btn-danger">Eliminar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="/static/js/manage_users.js"></script>
 </body>
 </html>

--- a/app/templates/user_config.html
+++ b/app/templates/user_config.html
@@ -8,6 +8,11 @@
   <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
+  <div id="overlay">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Procesando...</span>
+    </div>
+  </div>
   <div class="container" style="max-width: 500px;">
     <h2 class="text-center my-4">Config Usuario</h2>
     {% if error %}


### PR DESCRIPTION
## Summary
- revamp manage users page to use a single user selector
- add confirmation modals for changing role or deleting a user
- block actions with overlay spinner
- show overlay when deleting own account

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e7e9e043c83328f421216dd4e399b