### PR TITLE
Switch to Google Identity Services button

### DIFF
--- a/app/static/js/auth/login.js
+++ b/app/static/js/auth/login.js
@@ -38,4 +38,11 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
     }
   });
+
+  const googleBtn = document.getElementById('googleSignIn');
+  if (googleBtn) {
+    googleBtn.addEventListener('click', () => {
+      window.location.href = '/auth/google';
+    });
+  }
 });

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -25,16 +25,14 @@
       <button type="submit" class="btn btn-primary">Ingresar</button>
     </form>
       <div class="my-3 text-center">
-        <a href="/auth/google" class="btn btn-google w-100 d-flex align-items-center justify-content-center gap-2">
-          <img src="https://developers.google.com/identity/images/g-logo.png" alt="Google" width="20" height="20">
-          <span>Ingresar con Google</span>
-        </a>
+        <div id="googleSignIn" class="g_id_signin" data-theme="filled_blue" data-text="signup_with"></div>
       </div>
   <div class="text-center mt-2">
 
       <a href="/register">Registrarse</a>
     </div>
   </div>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="/static/js/auth/login.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- swap the login anchor for Google's official `g_id_signin` button
- load the Google Identity Services script
- redirect to `/auth/google` when the button is clicked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ed1a2703483329f708e6c48755b3c