### PR TITLE
Fix missing Google sign-in button

### DIFF
--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -28,7 +28,10 @@ router = APIRouter()
 
 @router.get("/login", response_class=HTMLResponse)
 def login_form(request: Request):
-    return templates.TemplateResponse("login.html", {"request": request})
+    google_client_id = os.getenv("GOOGLE_CLIENT_ID")
+    return templates.TemplateResponse(
+        "login.html", {"request": request, "google_client_id": google_client_id}
+    )
 
 
 @router.post("/login")
@@ -47,6 +50,7 @@ def login_action(
                 "error": "Credenciales inválidas",
                 "email": email,
                 "password": password,
+                "google_client_id": os.getenv("GOOGLE_CLIENT_ID"),
             },
             status_code=status.HTTP_400_BAD_REQUEST,
         )

--- a/app/static/js/auth/login.js
+++ b/app/static/js/auth/login.js
@@ -38,4 +38,11 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
     }
   });
+
+  const googleBtn = document.getElementById('googleSignIn');
+  if (googleBtn) {
+    googleBtn.addEventListener('click', () => {
+      window.location.href = '/auth/google';
+    });
+  }
 });

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -25,16 +25,14 @@
       <button type="submit" class="btn btn-primary">Ingresar</button>
     </form>
       <div class="my-3 text-center">
-        <a href="/auth/google" class="btn btn-google w-100 d-flex align-items-center justify-content-center gap-2">
-          <img src="https://developers.google.com/identity/images/g-logo.png" alt="Google" width="20" height="20">
-          <span>Ingresar con Google</span>
-        </a>
+        <div id="googleSignIn" class="g_id_signin" data-theme="filled_blue" data-text="signup_with" data-client_id="{{ google_client_id }}"></div>
       </div>
   <div class="text-center mt-2">
 
       <a href="/register">Registrarse</a>
     </div>
   </div>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="/static/js/auth/login.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- pass `GOOGLE_CLIENT_ID` to the login template
- include the id on the new `g_id_signin` element so the GIS script renders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ed1a2703483329f708e6c48755b3c