### PR TITLE
Fix Google sign-in redirect and session auth

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -81,6 +81,24 @@ app.add_middleware(
     max_age=SESSION_TIMEOUT,
 )
 
+
+@app.middleware("http")
+async def require_login(request: Request, call_next):
+    public_paths = {
+        "/login",
+        "/register",
+        "/auth/google",
+        "/auth/google/callback",
+        "/openapi.json",
+    }
+    if request.url.path.startswith("/static") or request.url.path.startswith("/docs"):
+        return await call_next(request)
+    if request.url.path in public_paths:
+        return await call_next(request)
+    if not request.session.get("user_id"):
+        return RedirectResponse("/login")
+    return await call_next(request)
+
 # Archivos estáticos
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -28,7 +28,10 @@ router = APIRouter()
 
 @router.get("/login", response_class=HTMLResponse)
 def login_form(request: Request):
-    return templates.TemplateResponse("login.html", {"request": request})
+    client_id = os.getenv("GOOGLE_CLIENT_ID")
+    return templates.TemplateResponse(
+        "login.html", {"request": request, "google_client_id": client_id}
+    )
 
 
 @router.post("/login")
@@ -40,6 +43,7 @@ def login_action(
 ):
     user = authenticate_user(db, email, password)
     if not user:
+        client_id = os.getenv("GOOGLE_CLIENT_ID")
         return templates.TemplateResponse(
             "login.html",
             {
@@ -47,12 +51,13 @@ def login_action(
                 "error": "Credenciales inválidas",
                 "email": email,
                 "password": password,
+                "google_client_id": client_id,
             },
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     request.session["user_id"] = user.id
     request.session["role"] = user.role.value
-    return RedirectResponse("/", status_code=status.HTTP_302_FOUND)
+    return RedirectResponse("/dashboard", status_code=status.HTTP_302_FOUND)
 
 
 @router.get("/register", response_class=HTMLResponse)

--- a/app/static/js/auth/login.js
+++ b/app/static/js/auth/login.js
@@ -38,4 +38,11 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
     }
   });
+  const googleBtn = document.getElementById("googleSignIn");
+  if (googleBtn) {
+    googleBtn.addEventListener("click", () => {
+      window.location.href = "/auth/google";
+    });
+  }
+
 });

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -25,10 +25,11 @@
       <button type="submit" class="btn btn-primary">Ingresar</button>
     </form>
       <div class="my-3 text-center">
-        <a href="/auth/google" class="btn btn-google w-100 d-flex align-items-center justify-content-center gap-2">
-          <img src="https://developers.google.com/identity/images/g-logo.png" alt="Google" width="20" height="20">
-          <span>Ingresar con Google</span>
-        </a>
+        <div id="googleSignIn"
+             class="g_id_signin"
+             data-client_id="{{ google_client_id }}"
+             data-theme="filled_blue"
+             data-text="signup_with"></div>
       </div>
   <div class="text-center mt-2">
 
@@ -36,5 +37,6 @@
     </div>
   </div>
   <script src="/static/js/auth/login.js"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure session middleware runs before auth check
- pass GOOGLE_CLIENT_ID into login template on both GET and failed POST
- update login template to use Google Identity Services button
- redirect GIS button click to `/auth/google`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ed1a2703483329f708e6c48755b3c