### PR TITLE
Require login for all routes

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,20 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from fastapi.responses import RedirectResponse
+
+
+class AuthRequiredMiddleware(BaseHTTPMiddleware):
+    """Middleware to ensure user is authenticated for protected routes."""
+
+    def __init__(self, app, public_paths=None):
+        super().__init__(app)
+        if public_paths is None:
+            public_paths = []
+        self.public_paths = public_paths
+
+    async def dispatch(self, request, call_next):
+        path = request.url.path
+        if any(path.startswith(p) for p in self.public_paths):
+            return await call_next(request)
+        if request.session.get("user_id"):
+            return await call_next(request)
+        return RedirectResponse("/login")

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from sqlalchemy import inspect, text
 from starlette.middleware.sessions import SessionMiddleware
 from fastapi.responses import RedirectResponse
+from app.core.auth import AuthRequiredMiddleware
 from app.core.db import Base, engine, SessionLocal
 from app.crud import users as crud_users
 from app.models.user import UserRole
@@ -79,6 +80,17 @@ app.add_middleware(
     SessionMiddleware,
     secret_key=os.getenv("SECRET_KEY", "secret"),
     max_age=SESSION_TIMEOUT,
+)
+app.add_middleware(
+    AuthRequiredMiddleware,
+    public_paths=[
+        "/login",
+        "/register",
+        "/auth/google",
+        "/auth/google/callback",
+        "/static",
+        "/",
+    ],
 )
 
 # Archivos estáticos


### PR DESCRIPTION
## Summary
- add authentication middleware
- register middleware in app startup to protect routes

## Testing
- `python -m py_compile app/main.py app/core/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_687fdee62780833289c30c8b8ab3a2f4