### PR TITLE
Fix auth middleware to enforce login

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,31 @@
+from typing import Iterable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from fastapi.responses import RedirectResponse
+
+
+class AuthRequiredMiddleware(BaseHTTPMiddleware):
+    """Middleware to ensure user is authenticated for protected routes."""
+
+    def __init__(self, app, public_paths: Iterable[str] | None = None,
+                 public_prefixes: Iterable[str] | None = None):
+        super().__init__(app)
+        self.public_paths = set(public_paths or [])
+        self.public_prefixes = tuple(public_prefixes or [])
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+
+        # Allow access to explicitly whitelisted paths
+        if path in self.public_paths:
+            return await call_next(request)
+
+        # Allow access to paths that share allowed prefixes (e.g. static files)
+        if any(path.startswith(prefix) for prefix in self.public_prefixes):
+            return await call_next(request)
+
+        if request.session.get("user_id"):
+            return await call_next(request)
+
+        return RedirectResponse("/login")

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from sqlalchemy import inspect, text
 from starlette.middleware.sessions import SessionMiddleware
 from fastapi.responses import RedirectResponse
+from app.core.auth import AuthRequiredMiddleware
 from app.core.db import Base, engine, SessionLocal
 from app.crud import users as crud_users
 from app.models.user import UserRole
@@ -79,6 +80,17 @@ app.add_middleware(
     SessionMiddleware,
     secret_key=os.getenv("SECRET_KEY", "secret"),
     max_age=SESSION_TIMEOUT,
+)
+app.add_middleware(
+    AuthRequiredMiddleware,
+    public_paths=[
+        "/login",
+        "/register",
+        "/auth/google",
+        "/auth/google/callback",
+        "/",
+    ],
+    public_prefixes=["/static"],
 )
 
 # Archivos estáticos


### PR DESCRIPTION
## Summary
- refine `AuthRequiredMiddleware` to handle exact paths and prefixes
- register new prefixes in `main.py`

## Testing
- `python -m py_compile app/main.py app/core/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_687fdee62780833289c30c8b8ab3a2f4