### PR TITLE
Store product info in sale details

### DIFF
--- a/app/crud/ventas.py
+++ b/app/crud/ventas.py
@@ -47,6 +47,8 @@ def create_venta(db: Session, v: VentaCreate) -> Venta:
             DetalleVenta(
                 venta_id=venta.id,
                 producto_id=item.producto_id,
+                codigo_getoutside=prod.codigo_getoutside,
+                descripcion=prod.descripcion,
                 cantidad=item.cantidad,
                 precio_unitario=item.precio_unitario,
                 subtotal=item.cantidad * item.precio_unitario,

--- a/app/models/ventas.py
+++ b/app/models/ventas.py
@@ -27,6 +27,8 @@ class DetalleVenta(Base):
     id = Column(Integer, primary_key=True, index=True)
     venta_id = Column(Integer, ForeignKey("ventas.id"), nullable=False)
     producto_id = Column(Integer, ForeignKey("productos.id"), nullable=False)
+    codigo_getoutside = Column(String, nullable=False)
+    descripcion = Column(String, nullable=False)
     cantidad = Column(Integer, nullable=False)
     precio_unitario = Column(DECIMAL(12, 2), nullable=False)
     subtotal = Column(DECIMAL(14, 2), nullable=False)

--- a/app/schemas/venta.py
+++ b/app/schemas/venta.py
@@ -21,6 +21,8 @@ class DetalleVentaOut(DetalleVentaIn):
     Esquema de salida para detalle de venta, con subtotal calculado.
     """
 
+    codigo_getoutside: str  # Código del producto al momento de la venta
+    descripcion: str  # Descripción guardada del producto
     subtotal: float  # cantidad * precio_unitario
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/templates/venta_detalle.html
+++ b/app/templates/venta_detalle.html
@@ -16,7 +16,7 @@
     <h5 class="mb-3">Productos</h5>
     {% for d in venta.detalles %}
       <div class="producto-block mb-3">
-        <div><strong>{{ d.producto.codigo_getoutside }}</strong> - {{ d.producto.descripcion }}</div>
+        <div><strong>{{ d.codigo_getoutside }}</strong> - {{ d.descripcion }}</div>
         <div class="d-flex justify-content-between text-muted">
           <span>
             Cantidad: {{ d.cantidad }} &nbsp;&nbsp;&nbsp;

--- a/app/templates/ventas_list.html
+++ b/app/templates/ventas_list.html
@@ -27,8 +27,8 @@
             <td>
               {% for d in v.detalles %}
                 <span>
-                  {{ d.producto.codigo_getoutside }}
-                  <span class="d-none d-md-inline"> - {{ d.producto.descripcion }}</span>
+                  {{ d.codigo_getoutside }}
+                  <span class="d-none d-md-inline"> - {{ d.descripcion }}</span>
                 </span>{% if not loop.last %}, {% endif %}
               {% endfor %}
             </td>


### PR DESCRIPTION
## Summary
- preserve product information when a sale is created
- show stored product data in sale listings and detail views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811d1deea483328d4033958c82ea21