### PR TITLE
Clean startup database initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ import os
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-from sqlalchemy import inspect, text
+
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.core.auth import AuthRequiredMiddleware
@@ -11,32 +11,8 @@ from app.core import config
 from app.crud import users as crud_users
 from app.models.user import UserRole
 
-# Crear columnas faltantes
-def _ensure_extra_columns():
-    inspector = inspect(engine)
-    cols = [c["name"] for c in inspector.get_columns("productos")]
-    with engine.connect() as conn:
-        if "foto_filename" not in cols:
-            conn.execute(text("ALTER TABLE productos ADD COLUMN foto_filename VARCHAR"))
-        if "costo_produccion" not in cols:
-            conn.execute(text("ALTER TABLE productos ADD COLUMN costo_produccion DECIMAL(12,2)"))
-        conn.commit()
-
-    cols = [c["name"] for c in inspector.get_columns("users")]
-    with engine.connect() as conn:
-        if "first_name" not in cols:
-            conn.execute(text("ALTER TABLE users ADD COLUMN first_name VARCHAR"))
-        if "last_name" not in cols:
-            conn.execute(text("ALTER TABLE users ADD COLUMN last_name VARCHAR"))
-        if "oauth_provider" not in cols:
-            conn.execute(text("ALTER TABLE users ADD COLUMN oauth_provider VARCHAR"))
-        if "foto_filename" not in cols:
-            conn.execute(text("ALTER TABLE users ADD COLUMN foto_filename VARCHAR"))
-        conn.commit()
-
-# Crear tablas y columnas
+# Crear tablas
 Base.metadata.create_all(bind=engine)
-_ensure_extra_columns()
 
 # Crear admin si no existe
 def _ensure_admin_user():


### PR DESCRIPTION
## Summary
- remove the `_ensure_extra_columns` function
- rely on `Base.metadata.create_all` for table creation only

## Testing
- `python -m py_compile $(find app -name '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812fab0cdc833281ab045183462069